### PR TITLE
fix: Specify file encoding in code2png

### DIFF
--- a/src/baseconversion.py
+++ b/src/baseconversion.py
@@ -34,7 +34,7 @@ class baseconversion:
         print("Code 2 Photo\n")
         for filename in os.listdir(self.infolder):
             filepath = os.path.join(self.infolder, filename)
-            with open(filepath, "r") as f:
+            with open(filepath, "r", encoding="utf-8") as f:
                 data = f.read()
             binary_data = bytes(data, "utf-8")
             print(f"File Bytes : {len(binary_data)}")


### PR DESCRIPTION
With some environment, open file without specifying encoding might be raise an error.
```bash
(venv) C:\Users\OWNER\Documents\_github\Imgrar>convert.py -input ./in -output ./out -code2png 1
ImgRar v1.0
Convert Small-Medium codes to Images And Vice-Versa
Code 2 Photo

Traceback (most recent call last):
  File "C:\Users\OWNER\Documents\_github\Imgrar\convert.py", line 34, in <module>
    objbase.code2png()
  File "C:\Users\OWNER\Documents\_github\Imgrar\src\baseconversion.py", line 39, in code2png
    data = f.read()
UnicodeDecodeError: 'cp949' codec can't decode byte 0xe2 in position 1660: illegal multibyte sequence
```

So I specify file encoding in `code2png` function and it works well.
```diff
def code2png(self):
        print("Code 2 Photo\n")
        for filename in os.listdir(self.infolder):
            filepath = os.path.join(self.infolder, filename)
--            with open(filepath, "r") as f:
++            with open(filepath, "r", encoding="utf-8") as f:
                data = f.read()
...
```

```bash
(venv) C:\Users\OWNER\Documents\_github\Imgrar>convert.py -input ./in -output ./out -code2png 1
ImgRar v1.0
Convert Small-Medium codes to Images And Vice-Versa
Code 2 Photo

File Bytes : 2383
Image dim : (300, 256)
baseconversion.py ✅

File Bytes : 300
Image dim : (300, 256)
config.json ✅
....
```